### PR TITLE
chore: add prerelease changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: git+https://github.com/MetaMask/ens-resolver-snap/


### PR DESCRIPTION
ran `yarn auto-changelog init`, in case it doesn't happen automatically.
This might be needed before #24. 