### PR TITLE
chore: check for INFURA_PROJECT_ID during setup

### DIFF
--- a/snap.config.ts
+++ b/snap.config.ts
@@ -4,6 +4,11 @@ import { resolve } from 'path';
 
 dotenv.config();
 
+// eslint-disable-next-line n/no-process-env
+if (!process.env.INFURA_PROJECT_ID) {
+  throw new Error('INFURA_PROJECT_ID must be set as an environment variable.');
+}
+
 const config: SnapConfig = {
   bundler: 'webpack',
   input: resolve(__dirname, 'src/index.ts'),

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/ens-resolver-snap.git"
   },
   "source": {
-    "shasum": "E6EruYmkaogoIAC6S1rBkJH7dN9SSuXfye8LWQzI/yk=",
+    "shasum": "/Ygi3sPZA1mWRQZ1JORa80Niu+TIagclIAFCRPWSlQs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,6 @@ import type {
 import type { AbstractProvider, AddressLike } from 'ethers';
 import { BrowserProvider, InfuraProvider } from 'ethers';
 
-// eslint-disable-next-line no-restricted-globals
-const infuraProjectId = process.env.INFURA_PROJECT_ID;
-
 const ENS_SUPPORTED_CHAINS = ['eip155:1', 'eip155:11155111', 'eip155:17000'];
 const PROTOCOL_NAME = 'Ethereum Name Service';
 
@@ -46,6 +43,11 @@ export const onNameLookup: OnNameLookupHandler = async (
   if (ENS_SUPPORTED_CHAINS.includes(chainId)) {
     provider = new BrowserProvider(ethereum, chainIdInt);
   } else {
+    // eslint-disable-next-line no-restricted-globals
+    const infuraProjectId = process.env.INFURA_PROJECT_ID;
+    if (!infuraProjectId) {
+      throw new Error('INFURA_PROJECT_ID is missing.');
+    }
     provider = new InfuraProvider(1, infuraProjectId);
   }
 


### PR DESCRIPTION
This snap requires an INFURA_PROJECT_ID for now and it was set up to grab it from `.env`, following [this guide](https://docs.metamask.io/snaps/how-to/use-environment-variables/).
But it looks like the project ID is not getting included in the build, so I'm adding these checks to try to understand where the failure is coming from.