### PR TITLE
chore: update Metamask/action-is-release and use env var instead of .env

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -30,8 +30,9 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
       - run: yarn --immutable --immutable-cache
-      - run: echo "INFURA_PROJECT_ID=${{ secrets.INFURA_PROJECT_ID }}" > ./.env
       - run: yarn build
+        env:
+          INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
       - name: Cache snap build
         uses: actions/cache@v4
         with:
@@ -86,9 +87,10 @@ jobs:
           path: ./dist
           key: snap-${{ runner.os }}-${{ github.sha }}
       - run: yarn install --immutable
-      - run: echo "INFURA_PROJECT_ID=${{ secrets.INFURA_PROJECT_ID }}" > .env
       - name: Run e2e tests
         run: yarn test
+        env:
+           INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     runs-on: ubuntu-latest
     steps:
-      - uses: MetaMask/action-is-release@v1
+      - uses: MetaMask/action-is-release@v2
         id: is-release
 
   publish-release:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -40,8 +40,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: yarn --immutable
-      - run: echo "INFURA_PROJECT_ID=${{ secrets.INFURA_PROJECT_ID }}" > .env
       - run: yarn build
+        env:
+          INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
 
   publish-npm-dry-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR is a follow up to [this discussion](https://github.com/MetaMask/ens-resolver-snap/pull/39#discussion_r1726878860)
No functionality changes in the library, but the CI workflows get some small updates regarding the use of `INFURA_PROJECT_ID` as an env var, and a bump in the version of `MetaMask/action-is-release` to clear up a warning about node versions.