### PR TITLE
fix: Move dependencies to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,6 @@
     "prepublishOnly": "mm-snap manifest",
     "test": "jest"
   },
-  "dependencies": {
-    "@metamask/snaps-sdk": "^6.9.0",
-    "ethers": "^6.13.1"
-  },
   "devDependencies": {
     "@jest/globals": "29.5.0",
     "@lavamoat/allow-scripts": "3.0.4",
@@ -49,6 +45,7 @@
     "@metamask/eslint-config-typescript": "12.1.0",
     "@metamask/snaps-cli": "6.3.0",
     "@metamask/snaps-jest": "8.3.0",
+    "@metamask/snaps-sdk": "^6.9.0",
     "@typescript-eslint/eslint-plugin": "5.42.1",
     "@typescript-eslint/parser": "5.42.1",
     "dotenv": "16.4.5",
@@ -60,6 +57,7 @@
     "eslint-plugin-n": "17.9.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-promise": "6.4.0",
+    "ethers": "^6.13.1",
     "jest": "29.5.0",
     "prettier": "2.8.8",
     "prettier-plugin-packagejson": "2.5.1",


### PR DESCRIPTION
Since all the Snap code is fully encapsulated in the produced bundle on NPM we don't need any dependencies in the dependency tree to run the Snap. They can be dev dependencies instead.