### PR TITLE
Add `chains` caveat to `name-lookup` endowment

### DIFF
--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -18,7 +18,9 @@
     }
   },
   "initialPermissions": {
-    "endowment:name-lookup": {},
+    "endowment:name-lookup": {
+      "chains": ["eip155:1", "eip155:11155111", "eip155:17000"]
+    },
     "endowment:network-access": {},
     "endowment:ethereum-provider": {}
   },


### PR DESCRIPTION
This PR adds the `chains` caveat to the `name-lookup` endowment to ensure the snap only gets called when trying to resolve on supported chains.