### PR TITLE
fix: Use a different ENS name for E2E

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -55,7 +55,7 @@ describe('onNameLookup', () => {
         const chainId = 59144;
 
         const result = await onNameLookup({
-          domain: 'vitalik.eth',
+          domain: 'nick.eth',
           chainId: `eip155:${chainId}`,
         });
 
@@ -67,7 +67,7 @@ describe('onNameLookup', () => {
             {
               resolvedAddress: expect.any(String),
               protocol: '⚠️ Ethereum Name Service (mainnet)',
-              domainName: 'vitalik.eth',
+              domainName: 'nick.eth',
             },
           ],
         });


### PR DESCRIPTION
Use a different name for E2E tests since they are currently hitting live nodes and the existing test had broken.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `vitalik.eth` with `nick.eth` in `src/index.test.ts` for the mainnet EOA resolution test and updates the expected domain accordingly.
> 
> - **Tests**:
>   - Update `src/index.test.ts` mainnet EOA resolution test to use `nick.eth` instead of `vitalik.eth`, including expected `domainName`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb83bc70d257039683bf670628240f2e99f89bbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->