### PR TITLE
fix: Update protocol name when resolving L2 addresses on mainnet

### DIFF
--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/ens-resolver-snap.git"
   },
   "source": {
-    "shasum": "2CN44094GdMSMlMosIgy8XnpV8jqAHmPibP7R5za3ls=",
+    "shasum": "/jmnL2KCWPOocT4V2PJNkcg5N9mr5p7e3xso1I+qg7Q=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/ens-resolver-snap.git"
   },
   "source": {
-    "shasum": "/jmnL2KCWPOocT4V2PJNkcg5N9mr5p7e3xso1I+qg7Q=",
+    "shasum": "GfXXSXPCG5lI22fSodkeMxlNODkltGueNRCyOL9sbNk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,9 @@ import type { CaipChainId } from '@metamask/utils';
  */
 export const PROTOCOL_NAME = 'Ethereum Name Service';
 
+export const PROTOCOL_NAME_MAINNET =
+  'Ethereum Name Service on Ethereum Mainnet';
+
 /**
  * List of supported chains for ENS resolution.
  */

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -42,7 +42,7 @@ describe('onNameLookup', () => {
           resolvedAddresses: [
             {
               resolvedAddress: '0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5',
-              protocol: '⚠️ Ethereum Name Service (mainnet)',
+              protocol: 'Ethereum Name Service on Ethereum Mainnet',
               domainName: 'nick.eth',
             },
           ],

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -2,7 +2,7 @@ import type { CaipNamespace } from '@metamask/utils';
 import { KnownCaipNamespace } from '@metamask/utils';
 import type { BrowserProvider } from 'ethers';
 
-import { PROTOCOL_NAME } from './constants';
+import { PROTOCOL_NAME, PROTOCOL_NAME_MAINNET } from './constants';
 import { addressIsContract } from './utils';
 
 /**
@@ -56,7 +56,7 @@ export async function resolveDomain(
 
     return {
       resolvedAddress: mainnetAddress,
-      protocol: `⚠️ ${PROTOCOL_NAME} (${(await provider.getNetwork()).name})`,
+      protocol: PROTOCOL_NAME_MAINNET,
       domainName: domain,
     };
   }


### PR DESCRIPTION
This PR updates the protocol name returned during a resolution for a L2 address using mainnet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes protocol label to "Ethereum Name Service on Ethereum Mainnet" for L2 lookups that resolve to mainnet, adds a constant, updates tests, and refreshes manifest shasum.
> 
> - **Resolution logic**:
>   - In `src/resolvers.ts`, replace dynamic warning protocol string with `PROTOCOL_NAME_MAINNET` when L2 lookups resolve to mainnet addresses.
> - **Constants**:
>   - Add `PROTOCOL_NAME_MAINNET` in `src/constants.ts`.
> - **Tests**:
>   - Update expectations in `src/index.test.ts` to use the new mainnet protocol label.
> - **Manifest**:
>   - Update `source.shasum` in `snap.manifest.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9c3ee55b4a396356eaa90719a8981ebec4fed11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->