### PR TITLE
chore: Update TypeScript to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "rimraf": "3.0.2",
     "sharp": "0.32.6",
     "ts-jest": "29.1.0",
-    "typescript": "4.8.4"
+    "typescript": "~5.3.3"
   },
   "packageManager": "yarn@3.2.1",
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,7 +1054,7 @@ __metadata:
     rimraf: 3.0.2
     sharp: 0.32.6
     ts-jest: 29.1.0
-    typescript: 4.8.4
+    typescript: ~5.3.3
   languageName: unknown
   linkType: soft
 
@@ -9883,23 +9883,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.8.4":
-  version: 4.8.4
-  resolution: "typescript@npm:4.8.4"
+"typescript@npm:~5.3.3":
+  version: 5.3.3
+  resolution: "typescript@npm:5.3.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
+  checksum: 2007ccb6e51bbbf6fde0a78099efe04dc1c3dfbdff04ca3b6a8bc717991862b39fd6126c0c3ebf2d2d98ac5e960bcaa873826bb2bb241f14277034148f41f6a2
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.8.4#~builtin<compat/typescript>":
-  version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=7ad353"
+"typescript@patch:typescript@~5.3.3#~builtin<compat/typescript>":
+  version: 5.3.3
+  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 563a0ef47abae6df27a9a3ab38f75fc681f633ccf1a3502b1108e252e187787893de689220f4544aaf95a371a4eb3141e4a337deb9895de5ac3c1ca76430e5f0
+  checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update TypeScript to `v5` using the same version range as in `core`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> TypeScript major-version upgrades can surface new type errors or change emit/type-checking behavior, potentially breaking builds or CI even without runtime code changes.
> 
> **Overview**
> Updates the development toolchain by bumping `typescript` from `4.8.4` to `~5.3.3` in `package.json` and syncing `yarn.lock` (including the Yarn compat patch entry) to the new TypeScript resolution.
> 
> No runtime code changes are included; the impact is limited to compilation/type-checking behavior and any downstream tooling that depends on the TypeScript version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 653c33466d67b11cdf10d3afdae8733eda96db67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->